### PR TITLE
Don't check for file changes

### DIFF
--- a/8/8.0/etc/php/production.ini
+++ b/8/8.0/etc/php/production.ini
@@ -34,8 +34,7 @@ opcache.interned_strings_buffer = 16
 opcache.max_accelerated_files = 10000
 opcache.fast_shutdown = 1
 opcache.enable_cli = 1
-opcache.revalidate_freq = 3600
-opcache.validate_timestamps = 1
+opcache.validate_timestamps = 0
 
 ; XDebug
 xdebug.remote_enable           = 0

--- a/8/8.0/etc/php/production.ini
+++ b/8/8.0/etc/php/production.ini
@@ -35,6 +35,7 @@ opcache.max_accelerated_files = 10000
 opcache.fast_shutdown = 1
 opcache.enable_cli = 1
 opcache.validate_timestamps = 0
+;opcache.revalidate_freq = 10
 
 ; XDebug
 xdebug.remote_enable           = 0


### PR DESCRIPTION
Don't check for changes in production. Force a reload/redeploy on code changes. If PHP checks every 3600 seconds behavior is rather unpredictable.